### PR TITLE
change `here` to an accessible link (`v1.0 tag`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-This repo hosts some binary blobs for duckdb using the release asset trick/hack - files can be added [here](https://github.com/duckdb/duckdb-data/releases/tag/v1.0) by editing the release
+This repo hosts some binary blobs for duckdb using the release asset trick/hack - files can be added to the [v1.0 tag](https://github.com/duckdb/duckdb-data/releases/tag/v1.0) by editing the release


### PR DESCRIPTION
For more information, see:
* https://www.w3.org/QA/Tips/noClickHere
* https://webaim.org/techniques/hypertext/link_text
* https://granicus.com/blog/why-click-here-links-are-bad/
* https://heyoka.medium.com/dont-use-click-here-f32f445d1021
